### PR TITLE
Add `OwnerReference` for `LoadBalancerRouting`

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
             - --authorization-kubeconfig=/etc/kubernetes/kubeconfig
             - --use-service-account-credentials
             - --leader-elect=true
+            - --requestheader-client-ca-file=/etc/config/ca
             - --secure-port=10245
             - --v=2
           image: controller:latest
@@ -60,6 +61,9 @@ spec:
             - mountPath: /etc/cloud
               name: cloud-config
               readOnly: true
+            - mountPath: /etc/config
+              name: kube-root-ca
+              readOnly: true
       volumes:
         - secret:
             secretName: cloud-config
@@ -73,6 +77,12 @@ spec:
         - secret:
             secretName: onmetalkubeconfig
           name: onmetalkubeconfig
+        - configMap:
+            name: kube-root-ca.crt
+            items:
+            - key: ca.crt
+              path: ca
+          name: kube-root-ca 
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"

--- a/docs/deployment/deploy_manually.md
+++ b/docs/deployment/deploy_manually.md
@@ -48,7 +48,8 @@ kind get kubeconfig > ./config/kind/kubeconfig
 
 * Run below make target to deploy the ``cloud-provider-onmetal``
 ```shell
-make kind-deploy
+make docker-build
+kustomize build config/kind | kubectl apply -f -
 ```
 **Validation:**
 ```
@@ -64,5 +65,5 @@ default kind cluster.
 To remove the cloud-controller from your cluster, simply run
 
 ```shell
-make kind-delete
+kustomize build config/kind | kubectl delete -f -
 ```

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -27,10 +27,11 @@ kind get kubeconfig > ./config/kind/kubeconfig
 ```
 Create cloud-config file under ./config/kind/ with the help of sample file present under ./config/sample/cloud-config 
 
-A make target that build and load the cloud controller into the kind cluster, then apply the config. Restarts cloud controller if they were present via
+Build and load the cloud controller into the kind cluster, then apply the config.
 
 ```shell
-make kind-deploy
+make docker-build
+kustomize build config/kind | kubectl apply -f -
 ```
 
 **Note**: In case that there are multiple environments running, ensure that `kind get clusters` is pointing to the
@@ -41,5 +42,5 @@ default kind cluster.
 To remove the cloud-controller from your cluster, simply run
 
 ```shell
-make kind-delete
+kustomize build config/kind | kubectl delete -f -
 ```

--- a/pkg/cloudprovider/onmetal/load_balancer.go
+++ b/pkg/cloudprovider/onmetal/load_balancer.go
@@ -208,7 +208,7 @@ func (o *onmetalLoadBalancer) applyLoadBalancerRoutingForLoadBalancer(ctx contex
 		Destinations: networkInterfaces,
 	}
 
-	if err := o.onmetalClient.Patch(ctx, loadBalancerRouting, client.Apply, loadBalancerFieldOwner, client.ForceOwnership); err != nil {
+	if err := o.onmetalClient.Patch(ctx, loadBalancerRouting, client.Apply, client.FieldOwner(loadBalancerFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply LoadBalancerRouting %s for LoadBalancer %s: %w", client.ObjectKeyFromObject(loadBalancerRouting), client.ObjectKeyFromObject(loadBalancer), err)
 	}
 	return nil

--- a/pkg/cloudprovider/onmetal/load_balancer.go
+++ b/pkg/cloudprovider/onmetal/load_balancer.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
@@ -208,14 +210,18 @@ func (o *onmetalLoadBalancer) applyLoadBalancerRoutingForLoadBalancer(ctx contex
 		Destinations: networkInterfaces,
 	}
 
-	if err := o.onmetalClient.Patch(ctx, loadBalancerRouting, client.Apply, client.FieldOwner(loadBalancerFieldOwner), client.ForceOwnership); err != nil {
+	if err := controllerutil.SetOwnerReference(loadBalancer, loadBalancerRouting, o.onmetalClient.Scheme()); err != nil {
+		return fmt.Errorf("failed to set owner reference for load balancer routing %s: %w", client.ObjectKeyFromObject(loadBalancerRouting), err)
+	}
+
+	if err := o.onmetalClient.Patch(ctx, loadBalancerRouting, client.Apply, loadBalancerFieldOwner, client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply LoadBalancerRouting %s for LoadBalancer %s: %w", client.ObjectKeyFromObject(loadBalancerRouting), client.ObjectKeyFromObject(loadBalancer), err)
 	}
 	return nil
 }
 
 func (o *onmetalLoadBalancer) getNetworkInterfacesForNodes(ctx context.Context, nodes []*v1.Node, networkName string) ([]commonv1alpha1.LocalUIDReference, error) {
-	var networkInterfaces = []commonv1alpha1.LocalUIDReference{}
+	var networkInterfaces []commonv1alpha1.LocalUIDReference
 	for _, node := range nodes {
 		machine := &computev1alpha1.Machine{}
 		if err := o.onmetalClient.Get(ctx, client.ObjectKey{Namespace: o.onmetalNamespace, Name: node.Name}, machine); client.IgnoreNotFound(err) != nil {

--- a/pkg/cloudprovider/onmetal/load_balancer_test.go
+++ b/pkg/cloudprovider/onmetal/load_balancer_test.go
@@ -18,10 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
-	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
-	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
-	"github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
+	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
+	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
+	"github.com/onmetal/onmetal-api/utils/testing"
 )
 
 const clusterName = "dev"
@@ -495,16 +496,11 @@ var _ = Describe("LoadBalancer", func() {
 			Status: corev1.ServiceStatus{},
 		}
 
-		By("ensuring that LoadBalancer instance is deleted")
+		By("ensuring that LoadBalancer instance is deleted successfully")
 		Eventually(func(g Gomega) {
 			err := lb.EnsureLoadBalancerDeleted(ctx, "envtest", service)
 			g.Expect(err).NotTo(HaveOccurred())
 		}).Should(Succeed())
 
-		By("ensuring that LoadBalancer deletion does not return an error if the LB is deleted")
-		Eventually(func(g Gomega) {
-			err := lb.EnsureLoadBalancerDeleted(ctx, "envtest", service)
-			g.Expect(err).NotTo(HaveOccurred())
-		}).Should(Succeed())
 	})
 })

--- a/pkg/cloudprovider/onmetal/load_balancer_test.go
+++ b/pkg/cloudprovider/onmetal/load_balancer_test.go
@@ -317,7 +317,7 @@ var _ = Describe("LoadBalancer", func() {
 			}))
 		}).Should(Succeed())
 
-		items := []commonv1alpha1.LocalUIDReference{}
+		var items []commonv1alpha1.LocalUIDReference
 		nic1 := &networkingv1alpha1.NetworkInterface{}
 		nic2 := &networkingv1alpha1.NetworkInterface{}
 		nic3 := &networkingv1alpha1.NetworkInterface{}
@@ -348,13 +348,18 @@ var _ = Describe("LoadBalancer", func() {
 			items = append(items, item)
 		}
 
-		By("ensuring that the destination addresses are updated")
+		By("ensuring that the load balancer routing is matching the destinations")
 		Eventually(func(g Gomega) {
 			err := loadbalancer.UpdateLoadBalancer(ctx, clusterName, service, []*corev1.Node{node1, node2})
 			g.Expect(err).NotTo(HaveOccurred())
 			lbRouting := &networkingv1alpha1.LoadBalancerRouting{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: service.Namespace, Name: string(lbName)}, lbRouting)).To(Succeed())
-			By("getting lbRouting ")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: service.Namespace, Name: lbName}, lbRouting)).To(Succeed())
+			g.Expect(lbRouting.OwnerReferences).To(ContainElement(metav1.OwnerReference{
+				APIVersion: "networking.api.onmetal.de/v1alpha1",
+				Kind:       "LoadBalancer",
+				Name:       lbName,
+				UID:        lb.UID,
+			}))
 			g.Expect(items).To(Equal(lbRouting.Destinations))
 		}).Should(Succeed())
 
@@ -364,8 +369,7 @@ var _ = Describe("LoadBalancer", func() {
 			err := loadbalancer.UpdateLoadBalancer(ctx, clusterName, service, []*corev1.Node{node2})
 			g.Expect(err).NotTo(HaveOccurred())
 			lbRouting := &networkingv1alpha1.LoadBalancerRouting{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: service.Namespace, Name: string(lbName)}, lbRouting)).To(Succeed())
-			By("getting lbRouting ")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: service.Namespace, Name: lbName}, lbRouting)).To(Succeed())
 			g.Expect(items).To(Equal(lbRouting.Destinations))
 		}).Should(Succeed())
 
@@ -425,7 +429,7 @@ var _ = Describe("LoadBalancer", func() {
 		service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
 			{IP: "10.0.0.1"},
 		}
-		By("ensuring that GetLoadBalancer returns loadbalancer status")
+		By("ensuring that GetLoadBalancer returns the correct load-balancer status")
 		Eventually(func(g Gomega) {
 			status, exist, err := lb.GetLoadBalancer(ctx, "envtest", service)
 			g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
# Proposed Changes

- Add owner reference to load balancer routing
- Remove unused variable
- Update comments for test functions
- Modify context of log messages for better readability
- Remove duplicate test for EnsureLoadBalancerDeleted
- Modify local setup doc

Fixes #188