### PR TITLE
Improve LoadBalancer tests

### DIFF
--- a/pkg/cloudprovider/onmetal/cloud_test.go
+++ b/pkg/cloudprovider/onmetal/cloud_test.go
@@ -15,14 +15,12 @@
 package onmetal
 
 import (
-	"github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Cloud", func() {
-	ctx := testing.SetupContext()
-	SetupTest(ctx)
+	SetupTest()
 
 	It("should ensure the correct cloud provider setup", func() {
 		Expect(cloudProvider.HasClusterID()).To(BeTrue())

--- a/pkg/cloudprovider/onmetal/load_balancer_test.go
+++ b/pkg/cloudprovider/onmetal/load_balancer_test.go
@@ -15,6 +15,9 @@
 package onmetal
 
 import (
+	"context"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -26,46 +29,28 @@ import (
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
-	"github.com/onmetal/onmetal-api/utils/testing"
 )
 
 var _ = Describe("LoadBalancer", func() {
+	const clusterName = "test"
 
-	const (
-		clusterName = "test-cluster"
-		serviceName = "test-service"
-	)
 	var (
 		service      *corev1.Service
-		node1        *corev1.Node
+		node         *corev1.Node
 		netInterface *networkingv1alpha1.NetworkInterface
-		lbName       string
-		loadBalancer *networkingv1alpha1.LoadBalancer
 	)
 
-	ctx := testing.SetupContext()
-	ns, olb, networkName := SetupTest(ctx)
+	ns, olb, network := SetupTest()
 
-	BeforeEach(func() {
-		By("creating test network")
-		network := &networkingv1alpha1.Network{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.Name,
-				Name:      networkName,
-			},
-		}
-		Expect(k8sClient.Create(ctx, network)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, network)
-
+	BeforeEach(func(ctx SpecContext) {
 		By("creating a network interface for machine1")
-		netInterface = newNetwrokInterface(ns.Name, "machine1-netinterface", networkName, "10.0.0.5")
+		netInterface = newNetworkInterface(ns.Name, "machine-networkinterface", network.Name, "10.0.0.5")
 		Expect(k8sClient.Create(ctx, netInterface)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, netInterface)
 
-		By("creating machine1")
+		By("creating machine")
 		networkInterfaces := []computev1alpha1.NetworkInterface{
 			{
-				Name: "netinterface",
+				Name: "networkinterface",
 				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
 					NetworkInterfaceRef: &corev1.LocalObjectReference{
 						Name: netInterface.Name,
@@ -73,23 +58,26 @@ var _ = Describe("LoadBalancer", func() {
 				},
 			},
 		}
-		machine1 := newMachine(ns.Name, "machine1", networkName, networkInterfaces)
-		Expect(k8sClient.Create(ctx, machine1)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, machine1)
+		machine := newMachine(ns.Name, "machine", networkInterfaces)
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 
-		By("creating node1 object with a provider ID referencing the machine1")
-		node1 = &corev1.Node{
+		By("creating node object with a provider ID referencing the machine1")
+		node = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: machine1.Name,
+				Name: machine.Name,
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(machine.Namespace, machine.Name),
 			},
 		}
-		Expect(k8sClient.Create(ctx, node1)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, node1)
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
 		By("creating test service of type LoadBalancer")
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceName,
-				Namespace: ns.Name,
+				GenerateName: "service-",
+				Namespace:    ns.Name,
 			},
 			Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeLoadBalancer,
@@ -99,268 +87,249 @@ var _ = Describe("LoadBalancer", func() {
 						Protocol:   "TCP",
 						Port:       443,
 						TargetPort: intstr.IntOrString{IntVal: 443},
-						NodePort:   31376,
 					},
 				},
 			},
 		}
 		Expect(k8sClient.Create(ctx, service)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, service)
-
-		lbName = olb.GetLoadBalancerName(ctx, clusterName, service)
-
-		By("creating test LoadBalancer object")
-		loadBalancer = &networkingv1alpha1.LoadBalancer{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.Name,
-				Name:      lbName,
-			},
-			Spec: networkingv1alpha1.LoadBalancerSpec{
-				Type:       networkingv1alpha1.LoadBalancerTypePublic,
-				IPFamilies: service.Spec.IPFamilies,
-				NetworkRef: corev1.LocalObjectReference{Name: networkName},
-			},
-		}
-		Expect(k8sClient.Create(ctx, loadBalancer)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, loadBalancer)
+		DeferCleanup(k8sClient.Delete, service)
 	})
 
-	It("should ensure external LoadBalancer", func() {
+	It("should ensure external LoadBalancer", func(ctx SpecContext) {
+		By("failing if no public IP is present for LoadBalancer")
+		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
 
-		By("creating a Node object")
-		node := &corev1.Node{
+		By("getting the LoadBalancer")
+		loadBalancer := &networkingv1alpha1.LoadBalancer{}
+		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, service)}
+		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
+
+		By("inspecting the LoadBalancer")
+		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
+
+		By("patching public IP into LoadBalancer status")
+		Eventually(UpdateStatus(loadBalancer, func() {
+			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}
+		})).Should(Succeed())
+
+		By("ensuring LoadBalancer for service")
+		Expect(olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).
+			To(Equal(&corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+			}))
+
+		By("waiting for the LoadBalancer object to report the IPs")
+		Eventually(Object(loadBalancer)).Should(HaveField("Status.IPs", []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}))
+	})
+
+	It("should ensure internal LoadBalancer", func(ctx SpecContext) {
+		By("creating test service of type internal LoadBalancer")
+		internalService := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
+				GenerateName: "service-",
+				Namespace:    ns.Name,
+				Annotations: map[string]string{
+					InternalLoadBalancerAnnotation: "true",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "https",
+						Protocol:   "TCP",
+						Port:       443,
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, node)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, node)
+		Expect(k8sClient.Create(ctx, internalService)).To(Succeed())
 
 		By("failing if no public IP is present for LoadBalancer")
-		status, err := olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})
-		Expect(status).To(BeNil())
-		Expect(err).To(HaveOccurred())
+		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, internalService, []*corev1.Node{node})).Error().To(HaveOccurred())
 
-		By("patching public IP into loadbalancer status")
-		lbBase := loadBalancer.DeepCopy()
-		loadBalancer.Status = networkingv1alpha1.LoadBalancerStatus{
-			IPs: []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")},
-		}
-		Expect(k8sClient.Status().Patch(ctx, loadBalancer, client.MergeFrom(lbBase))).To(Succeed())
+		By("getting the LoadBalancer")
+		loadBalancer := &networkingv1alpha1.LoadBalancer{}
+		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, internalService)}
+		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
 
-		By("creating LoadBalancer for service")
-		lbStatus, err := olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node1})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(lbStatus).To(Equal(&corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
-		}))
+		By("inspecting the LoadBalancer")
+		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypeInternal))
 
-		Eventually(Object(loadBalancer)).Should(SatisfyAll(
-			HaveField("Spec.Type", Equal(networkingv1alpha1.LoadBalancerTypePublic)),
-			HaveField("Status.IPs", []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}),
-		))
-	})
+		By("patching internal IP into LoadBalancer status")
+		Eventually(UpdateStatus(loadBalancer, func() {
+			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")}
+		})).Should(Succeed())
 
-	It("should ensure internal LoadBalancer", func() {
-		By("adding internal LoadBalancer annotation to service")
-		svcBase := service.DeepCopy()
-		service.Annotations = map[string]string{
-			InternalLoadBalancerAnnotation: "true",
-		}
-		Expect(k8sClient.Status().Patch(ctx, service, client.MergeFrom(svcBase))).To(Succeed())
-		Eventually(Object(service)).Should(SatisfyAll(
-			HaveField("Annotations", HaveKeyWithValue(InternalLoadBalancerAnnotation, "true")),
-		))
-
-		By("patching internal IP into loadbalancer status")
-		lbBase := loadBalancer.DeepCopy()
-		loadBalancer.Status = networkingv1alpha1.LoadBalancerStatus{
-			IPs: []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.2")},
-		}
-		Expect(k8sClient.Status().Patch(ctx, loadBalancer, client.MergeFrom(lbBase))).To(Succeed())
-
-		By("ensuring internal LoadBalancer for service")
-		lbStatus, err := olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node1})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(lbStatus).To(Equal(&corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
-		}))
-		Eventually(Object(loadBalancer)).Should(SatisfyAll(
-			HaveField("Spec.Type", Equal(networkingv1alpha1.LoadBalancerTypeInternal)),
-			HaveField("Status.IPs", []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.2")}),
-		))
+		By("ensuring LoadBalancer for service")
+		Expect(olb.EnsureLoadBalancer(ctx, clusterName, internalService, []*corev1.Node{node})).
+			To(Equal(&corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "100.0.0.1"}},
+			}))
 
 		By("removing internal LoadBalancer annotation from service")
-		svcBase = service.DeepCopy()
-		delete(service.Annotations, InternalLoadBalancerAnnotation)
-		Expect(k8sClient.Status().Patch(ctx, service, client.MergeFrom(svcBase))).To(Succeed())
-		Eventually(Object(service)).Should(SatisfyAll(
-			HaveField("Annotations", BeEmpty()),
-		))
+		Eventually(Update(internalService, func() {
+			internalService.Annotations = map[string]string{}
+		})).Should(Succeed())
 
-		By("patching public IP into loadbalancer status")
-		lbBase = loadBalancer.DeepCopy()
-		loadBalancer.Status = networkingv1alpha1.LoadBalancerStatus{
-			IPs: []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")},
-		}
-		Expect(k8sClient.Status().Patch(ctx, loadBalancer, client.MergeFrom(lbBase))).To(Succeed())
+		By("patching public IP into LoadBalancer status")
+		Eventually(UpdateStatus(loadBalancer, func() {
+			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}
+		})).Should(Succeed())
 
-		By("ensuring external LoadBalancer for service after removing internal LoadBalancer annotation")
-		lbStatus, err = olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node1})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(lbStatus).To(Equal(&corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
-		}))
-		Eventually(Object(loadBalancer)).Should(SatisfyAll(
-			HaveField("Spec.Type", Equal(networkingv1alpha1.LoadBalancerTypePublic)),
-			HaveField("Status.IPs", []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}),
-		))
+		By("ensuring LoadBalancer for service")
+		Expect(olb.EnsureLoadBalancer(ctx, clusterName, internalService, []*corev1.Node{node})).Error().NotTo(HaveOccurred())
+
+		By("ensuring that the LoadBalancer is of type public")
+		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
+		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
+
+		By("ensuring LoadBalancerStatus for service has the correct public IP")
+		Expect(olb.EnsureLoadBalancer(ctx, clusterName, internalService, []*corev1.Node{node})).
+			To(Equal(&corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+			}))
 	})
 
-	It("should update LoadBalancer", func() {
+	It("should update LoadBalancer", func(ctx SpecContext) {
+		By("creating a network interface for machine-2")
+		networkInterface2 := newNetworkInterface(ns.Name, "machine-2-networkinterface1", network.Name, "10.0.0.1")
+		Expect(k8sClient.Create(ctx, networkInterface2)).To(Succeed())
 
-		By("creating a network interface1 for machine 2")
-		netInterface1 := newNetwrokInterface(ns.Name, "machine2-netinterface1", networkName, "10.0.0.5")
-		Expect(k8sClient.Create(ctx, netInterface1)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, netInterface1)
+		By("creating a network interface for machine-2 in a different network")
+		networkInterfaceWithWrongNetwork := newNetworkInterface(ns.Name, "machine-2-networkinterface2", "foo", "20.0.0.2")
+		Expect(k8sClient.Create(ctx, networkInterfaceWithWrongNetwork)).To(Succeed())
 
-		By("creating a network interface2 for machine 2")
-		netInterface2 := newNetwrokInterface(ns.Name, "machine2-netinterface2", "my-network-2", "10.0.0.6")
-		Expect(k8sClient.Create(ctx, netInterface2)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, netInterface2)
-
-		By("creating machine2")
+		By("creating NetworkInterfaces for Machine 2")
 		networkInterfaces := []computev1alpha1.NetworkInterface{
 			{
-				Name: "netinterface1",
+				Name: "networkinterface1",
 				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
 					NetworkInterfaceRef: &corev1.LocalObjectReference{
-						Name: netInterface1.Name,
+						Name: networkInterface2.Name,
 					},
 				},
 			},
 			{
-				Name: "netinterface2",
+				Name: "networkinterface2",
 				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
 					NetworkInterfaceRef: &corev1.LocalObjectReference{
-						Name: netInterface2.Name,
+						Name: networkInterfaceWithWrongNetwork.Name,
 					},
 				},
 			},
 		}
-		machine2 := newMachine(ns.Name, "machine2", networkName, networkInterfaces)
+		machine2 := newMachine(ns.Name, "machine-2", networkInterfaces)
 		Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, machine2)
 
 		By("creating node2 object with a provider ID referencing the machine2")
 		node2 := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: machine2.Name,
 			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(machine2.Namespace, machine2.Name),
+			},
 		}
 		Expect(k8sClient.Create(ctx, node2)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, node2)
+		DeferCleanup(k8sClient.Delete, node2)
 
-		By("patching public IP into loadbalancer status")
-		lbBase := loadBalancer.DeepCopy()
-		loadBalancer.Status = networkingv1alpha1.LoadBalancerStatus{
-			IPs: []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")},
-		}
-		Expect(k8sClient.Status().Patch(ctx, loadBalancer, client.MergeFrom(lbBase))).To(Succeed())
+		By("failing if no public IP is present for LoadBalancer")
+		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
+
+		By("getting the LoadBalancer")
+		loadBalancer := &networkingv1alpha1.LoadBalancer{}
+		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, service)}
+		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
+
+		By("inspecting the LoadBalancer")
+		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
+
+		By("patching public IP into LoadBalancer status")
+		Eventually(UpdateStatus(loadBalancer, func() {
+			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")}
+		})).Should(Succeed())
 
 		By("creating LoadBalancer for service")
-		lbStatus, err := olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node1})
+		lbStatus, err := olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(lbStatus).To(Equal(&corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+			Ingress: []corev1.LoadBalancerIngress{{IP: "100.0.0.1"}},
 		}))
 
-		Eventually(Object(netInterface)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Namespace", ns.Name),
-			HaveField("ObjectMeta.Name", netInterface.Name),
-		))
-
-		Eventually(Object(netInterface1)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Namespace", ns.Name),
-			HaveField("ObjectMeta.Name", netInterface1.Name),
-		))
-
-		Eventually(Object(netInterface2)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Namespace", ns.Name),
-			HaveField("ObjectMeta.Name", netInterface2.Name),
-		))
-
-		By("ensuring destinations of load balancer routing gets updated for node1 and node2")
-		err = olb.UpdateLoadBalancer(ctx, clusterName, service, []*corev1.Node{node1, node2})
+		By("ensuring destinations of load balancer routing gets updated for node and node2")
+		err = olb.UpdateLoadBalancer(ctx, clusterName, service, []*corev1.Node{node, node2})
 		Expect(err).NotTo(HaveOccurred())
-		lbRouting := &networkingv1alpha1.LoadBalancerRouting{ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: lbName}}
+		lbRouting := &networkingv1alpha1.LoadBalancerRouting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: service.Namespace,
+				Name:      loadBalancer.Name,
+			},
+		}
 		Eventually(Object(lbRouting)).Should(SatisfyAll(
 			HaveField("ObjectMeta.OwnerReferences", ContainElement(metav1.OwnerReference{
 				APIVersion: "networking.api.onmetal.de/v1alpha1",
 				Kind:       "LoadBalancer",
-				Name:       lbName,
+				Name:       loadBalancer.Name,
 				UID:        loadBalancer.UID,
 			})),
-			// netInterface2 will not be listed in Destinations, because network "my-network-2" used by netInterface2 does not exist
+			// netInterface2 will not be listed in Destinations, because network "foo" used by netInterface2 does not exist
 			HaveField("Destinations", ContainElements([]commonv1alpha1.LocalUIDReference{
 				{
 					Name: netInterface.Name,
 					UID:  netInterface.UID,
 				},
 				{
-					Name: netInterface1.Name,
-					UID:  netInterface1.UID,
-				}}))))
-
-		By("ensuring destinations of load balancer routing gets updated for only node2")
-		err = olb.UpdateLoadBalancer(ctx, clusterName, service, []*corev1.Node{node2})
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(Object(lbRouting)).Should(SatisfyAll(
-			HaveField("Destinations", ContainElements(
-				[]commonv1alpha1.LocalUIDReference{{
-					Name: netInterface1.Name,
-					UID:  netInterface1.UID,
+					Name: networkInterface2.Name,
+					UID:  networkInterface2.UID,
 				}}))))
 	})
 
-	It("should get LoadBalancer info", func() {
-
-		service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
-			{IP: "10.0.0.1"},
-		}
-
-		lbBase := loadBalancer.DeepCopy()
-		loadBalancer.Status = networkingv1alpha1.LoadBalancerStatus{
-			IPs: []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")},
-		}
-		Expect(k8sClient.Status().Patch(ctx, loadBalancer, client.MergeFrom(lbBase))).To(Succeed())
-
-		By("ensuring that GetLoadBalancer returns the correct load-balancer status")
-		status, exist, err := olb.GetLoadBalancer(ctx, clusterName, service)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(exist).To(BeTrue())
-		Expect(status.Ingress).To(ContainElements(service.Status.LoadBalancer.Ingress))
-
-		By("ensuring that LoadBalancer returns instance not found for non existing object")
-		_, exist, err = olb.GetLoadBalancer(ctx, "envnon", service)
+	It("should get LoadBalancer info", func(ctx SpecContext) {
+		By("ensuring that GetLoadBalancer returns instance not found for non existing object")
+		_, exist, err := olb.GetLoadBalancer(ctx, "foo", service)
 		Expect(err).To(HaveOccurred())
 		Expect(exist).To(BeFalse())
-
 	})
 
-	It("should delete LoadBalancer", func() {
+	It("should delete LoadBalancer", func(ctx SpecContext) {
+		By("failing if no public IP is present for LoadBalancer")
+		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
 
-		Eventually(Object(loadBalancer)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Name", lbName),
-			HaveField("ObjectMeta.Namespace", ns.Name)))
+		By("getting the LoadBalancer")
+		loadBalancer := &networkingv1alpha1.LoadBalancer{}
+		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, service)}
+		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
 
-		By("ensuring that LoadBalancer instance is deleted successfully")
-		err := olb.EnsureLoadBalancerDeleted(ctx, "test", service)
-		Expect(err).NotTo(HaveOccurred())
+		By("inspecting the LoadBalancer")
+		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
+
+		By("patching public IP into LoadBalancer status")
+		Eventually(UpdateStatus(loadBalancer, func() {
+			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}
+		})).Should(Succeed())
+
+		By("ensuring LoadBalancer for service")
+		Expect(olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).
+			To(Equal(&corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+			}))
+
+		By("deleting the LoadBalancer")
+		Expect(olb.EnsureLoadBalancerDeleted(ctx, clusterName, service)).Error().To(Not(HaveOccurred()))
 	})
 })
 
-func newNetwrokInterface(namespace string, name string, networkName string, ip string) *networkingv1alpha1.NetworkInterface {
+func newNetworkInterface(namespace string, name string, networkName string, ip string) *networkingv1alpha1.NetworkInterface {
 	return &networkingv1alpha1.NetworkInterface{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -369,21 +338,11 @@ func newNetwrokInterface(namespace string, name string, networkName string, ip s
 		Spec: networkingv1alpha1.NetworkInterfaceSpec{
 			NetworkRef: corev1.LocalObjectReference{Name: networkName},
 			IPs:        []networkingv1alpha1.IPSource{{Value: commonv1alpha1.MustParseNewIP(ip)}},
-			VirtualIP: &networkingv1alpha1.VirtualIPSource{
-				Ephemeral: &networkingv1alpha1.EphemeralVirtualIPSource{
-					VirtualIPTemplate: &networkingv1alpha1.VirtualIPTemplateSpec{
-						Spec: networkingv1alpha1.VirtualIPSpec{
-							Type:     networkingv1alpha1.VirtualIPTypePublic,
-							IPFamily: corev1.IPv4Protocol,
-						},
-					},
-				},
-			},
 		},
 	}
 }
 
-func newMachine(namespace, name, networkName string, networkInterfaces []computev1alpha1.NetworkInterface) *computev1alpha1.Machine {
+func newMachine(namespace, name string, networkInterfaces []computev1alpha1.NetworkInterface) *computev1alpha1.Machine {
 	return &computev1alpha1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,


### PR DESCRIPTION
# Proposed Changes

- Use `SpecContext` in suite tests
- Improve suite test structure for `LoadBalancer` interface methods  
- Extract `Machine` name from `ProviderID` of the `Node` object instead of relying on the `Node` name