### PR TITLE
Update Go version and linters configuration

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
       - run: go mod tidy
       - run: hack/check.sh

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,11 +10,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
-      - uses: actions/checkout@v3
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.1
+          version: v1.53.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
       - run: make test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ linters:
     - misspell
     - goimports
     - importas
+    - ginkgolinter
 
 severity:
   default-severity: error


### PR DESCRIPTION
# Proposed Changes

- Update the `go-version-file` value in `.github/workflows/clean.yml` and `.github/workflows/golangci-lint.yml` from `go.mod` to `1.20`
- Update the `version` value in `.github/workflows/golangci-lint.yml` from `v1.52.1` to `v1.53.3`
- Update the `go-version-file` value in `.github/workflows/test.yml` from `go.mod` to `1.20`
- Add the `ginkgolinter` to the linters list in `.golangci.yaml`
