### PR TITLE
Fix `NetworkInterface` lookup in `LoadBalancer` controller and refactor suite tests for `Routes` and `LoadBalancer` 

### DIFF
--- a/pkg/cloudprovider/onmetal/cloud_test.go
+++ b/pkg/cloudprovider/onmetal/cloud_test.go
@@ -20,22 +20,22 @@ import (
 )
 
 var _ = Describe("Cloud", func() {
-	SetupTest()
+	_, cp, _, _ := SetupTest()
 
 	It("should ensure the correct cloud provider setup", func() {
-		Expect(cloudProvider.HasClusterID()).To(BeTrue())
+		Expect((*cp).HasClusterID()).To(BeTrue())
 
-		Expect(cloudProvider.ProviderName()).To(Equal("onmetal"))
+		Expect((*cp).ProviderName()).To(Equal("onmetal"))
 
-		clusters, ok := cloudProvider.Clusters()
+		clusters, ok := (*cp).Clusters()
 		Expect(clusters).To(BeNil())
 		Expect(ok).To(BeFalse())
 
-		instances, ok := cloudProvider.Instances()
+		instances, ok := (*cp).Instances()
 		Expect(instances).To(BeNil())
 		Expect(ok).To(BeFalse())
 
-		zones, ok := cloudProvider.Zones()
+		zones, ok := (*cp).Zones()
 		Expect(zones).To(BeNil())
 		Expect(ok).To(BeFalse())
 	})

--- a/pkg/cloudprovider/onmetal/load_balancer_test.go
+++ b/pkg/cloudprovider/onmetal/load_balancer_test.go
@@ -16,14 +16,16 @@ package onmetal
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	cloudprovider "k8s.io/cloud-provider"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
@@ -32,36 +34,71 @@ import (
 )
 
 var _ = Describe("LoadBalancer", func() {
+	ns, cp, network, clusterName := SetupTest()
 
 	var (
-		service      *corev1.Service
-		node         *corev1.Node
-		netInterface *networkingv1alpha1.NetworkInterface
+		lbProvider cloudprovider.LoadBalancer
 	)
 
-	ns, olb, network, clusterName := SetupTest()
-
 	BeforeEach(func(ctx SpecContext) {
-		By("creating a network interface for machine1")
-		netInterface = newNetworkInterface(ns.Name, "machine-networkinterface", network.Name, "10.0.0.5")
-		Expect(k8sClient.Create(ctx, netInterface)).To(Succeed())
+		By("instantiating the load balancer provider")
+		var ok bool
+		lbProvider, ok = (*cp).LoadBalancer()
+		Expect(ok).To(BeTrue())
+	})
 
-		By("creating machine")
-		networkInterfaces := []computev1alpha1.NetworkInterface{
-			{
-				Name: "networkinterface",
-				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
-					NetworkInterfaceRef: &corev1.LocalObjectReference{
-						Name: netInterface.Name,
-					},
+	It("should ensure external load balancer for service", func(ctx SpecContext) {
+		By("creating a machine object")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
+				Image:           "my-image:latest",
+				Volumes:         []computev1alpha1.Volume{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
+
+		By("creating a network interface for machine")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface"),
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.1"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
 				},
 			},
 		}
-		machine := newMachine(ns.Name, "machine", networkInterfaces)
-		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterface)
 
-		By("creating node object with a provider ID referencing the machine1")
-		node = &corev1.Node{
+		By("patching the network interfaces of the machine")
+		Eventually(Update(machine, func() {
+			machine.Spec.NetworkInterfaces = []computev1alpha1.NetworkInterface{
+				{
+					Name: "primary",
+					NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+						NetworkInterfaceRef: &corev1.LocalObjectReference{
+							Name: networkInterface.Name,
+						},
+					},
+				},
+			}
+		})).Should(Succeed())
+
+		By("creating node object with a provider ID referencing the machine")
+		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: machine.Name,
 			},
@@ -72,8 +109,8 @@ var _ = Describe("LoadBalancer", func() {
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, node)
 
-		By("creating test service of type LoadBalancer")
-		service = &corev1.Service{
+		By("creating test service of type load balancer")
+		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "service-",
 				Namespace:    ns.Name,
@@ -92,40 +129,122 @@ var _ = Describe("LoadBalancer", func() {
 		}
 		Expect(k8sClient.Create(ctx, service)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, service)
-	})
 
-	It("should ensure external LoadBalancer", func(ctx SpecContext) {
-		By("failing if no public IP is present for LoadBalancer")
-		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		By("failing if no public IP is present for load balancer")
+		lbCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
-		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
+		Expect(lbProvider.EnsureLoadBalancer(lbCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
 
-		By("getting the LoadBalancer")
-		loadBalancer := &networkingv1alpha1.LoadBalancer{}
-		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, service)}
-		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
+		By("ensuring the load balancer type is public")
+		loadBalancer := &networkingv1alpha1.LoadBalancer{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      lbProvider.GetLoadBalancerName(ctx, clusterName, service),
+			},
+		}
+		Eventually(Object(loadBalancer)).Should(SatisfyAll(
+			HaveField("Spec.Type", Equal(networkingv1alpha1.LoadBalancerTypePublic))))
 
-		By("inspecting the LoadBalancer")
-		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
-
-		By("patching public IP into LoadBalancer status")
+		By("patching public IP into load balancer status")
 		Eventually(UpdateStatus(loadBalancer, func() {
 			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}
 		})).Should(Succeed())
 
-		By("ensuring LoadBalancer for service")
-		Expect(olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).
-			To(Equal(&corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
-			}))
+		By("ensuring load balancer for service")
+		Expect(lbProvider.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).To(Equal(&corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+		}))
 
-		By("waiting for the LoadBalancer object to report the IPs")
-		Eventually(Object(loadBalancer)).Should(HaveField("Status.IPs", []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}))
+		By("ensuring destinations of load balancer routing")
+		lbRouting := &networkingv1alpha1.LoadBalancerRouting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: service.Namespace,
+				Name:      loadBalancer.Name,
+			},
+		}
+		Eventually(Object(lbRouting)).Should(SatisfyAll(
+			HaveField("ObjectMeta.OwnerReferences", ContainElement(metav1.OwnerReference{
+				APIVersion: "networking.api.onmetal.de/v1alpha1",
+				Kind:       "LoadBalancer",
+				Name:       loadBalancer.Name,
+				UID:        loadBalancer.UID,
+			})),
+			HaveField("Destinations", ContainElements([]commonv1alpha1.LocalUIDReference{
+				{
+					Name: networkInterface.Name,
+					UID:  networkInterface.UID,
+				},
+			})),
+		))
+
+		By("deleting the load balancer")
+		Expect(lbProvider.EnsureLoadBalancerDeleted(ctx, clusterName, service)).To(Succeed())
 	})
 
-	It("should ensure internal LoadBalancer", func(ctx SpecContext) {
-		By("creating test service of type internal LoadBalancer")
-		internalService := &corev1.Service{
+	It("should ensure an internal load balancer for service", func(ctx SpecContext) {
+		By("creating a machine object")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
+				Image:           "my-image:latest",
+				Volumes:         []computev1alpha1.Volume{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
+
+		By("creating a network interface for machine")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface"),
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.1"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterface)
+
+		By("patching the network interfaces of the machine")
+		Eventually(Update(machine, func() {
+			machine.Spec.NetworkInterfaces = []computev1alpha1.NetworkInterface{
+				{
+					Name: "primary",
+					NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+						NetworkInterfaceRef: &corev1.LocalObjectReference{
+							Name: networkInterface.Name,
+						},
+					},
+				},
+			}
+		})).Should(Succeed())
+
+		By("creating node object with a provider ID referencing the machine")
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: machine.Name,
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(machine.Namespace, machine.Name),
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
+		By("creating test service of type internal load balancer")
+		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "service-",
 				Namespace:    ns.Name,
@@ -145,35 +264,38 @@ var _ = Describe("LoadBalancer", func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, internalService)).To(Succeed())
+		Expect(k8sClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, service)
 
-		By("failing if no public IP is present for LoadBalancer")
-		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		By("ensuring load balancer for service")
+		lbCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
-		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, internalService, []*corev1.Node{node})).Error().To(HaveOccurred())
+		Expect(lbProvider.EnsureLoadBalancer(lbCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
 
-		By("getting the LoadBalancer")
-		loadBalancer := &networkingv1alpha1.LoadBalancer{}
-		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, internalService)}
-		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
+		By("ensuring the load balancer type is internal")
+		loadBalancer := &networkingv1alpha1.LoadBalancer{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      lbProvider.GetLoadBalancerName(ctx, clusterName, service),
+			},
+		}
+		Eventually(Object(loadBalancer)).Should(SatisfyAll(
+			HaveField("Spec.Type", Equal(networkingv1alpha1.LoadBalancerTypeInternal))))
 
-		By("inspecting the LoadBalancer")
-		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypeInternal))
-
-		By("patching internal IP into LoadBalancer status")
+		By("patching internal IP in load balancer status")
 		Eventually(UpdateStatus(loadBalancer, func() {
-			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")}
+			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.10")}
 		})).Should(Succeed())
 
-		By("ensuring LoadBalancer for service")
-		Expect(olb.EnsureLoadBalancer(ctx, clusterName, internalService, []*corev1.Node{node})).
+		By("ensuring load balancer for service")
+		Expect(lbProvider.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).
 			To(Equal(&corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{{IP: "100.0.0.1"}},
+				Ingress: []corev1.LoadBalancerIngress{{IP: "100.0.0.10"}},
 			}))
 
-		By("removing internal LoadBalancer annotation from service")
-		Eventually(Update(internalService, func() {
-			internalService.Annotations = map[string]string{}
+		By("removing internal load balancer annotation from service")
+		Eventually(Update(service, func() {
+			service.Annotations = map[string]string{}
 		})).Should(Succeed())
 
 		By("patching public IP into LoadBalancer status")
@@ -181,91 +303,16 @@ var _ = Describe("LoadBalancer", func() {
 			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}
 		})).Should(Succeed())
 
-		By("ensuring LoadBalancer for service")
-		Expect(olb.EnsureLoadBalancer(ctx, clusterName, internalService, []*corev1.Node{node})).Error().NotTo(HaveOccurred())
-
-		By("ensuring that the LoadBalancer is of type public")
-		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
-		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
-
-		By("ensuring LoadBalancerStatus for service has the correct public IP")
-		Expect(olb.EnsureLoadBalancer(ctx, clusterName, internalService, []*corev1.Node{node})).
-			To(Equal(&corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
-			}))
-	})
-
-	It("should update LoadBalancer", func(ctx SpecContext) {
-		By("creating a network interface for machine-2")
-		networkInterface2 := newNetworkInterface(ns.Name, "machine-2-networkinterface1", network.Name, "10.0.0.1")
-		Expect(k8sClient.Create(ctx, networkInterface2)).To(Succeed())
-
-		By("creating a network interface for machine-2 in a different network")
-		networkInterfaceWithWrongNetwork := newNetworkInterface(ns.Name, "machine-2-networkinterface2", "foo", "20.0.0.2")
-		Expect(k8sClient.Create(ctx, networkInterfaceWithWrongNetwork)).To(Succeed())
-
-		By("creating NetworkInterfaces for Machine 2")
-		networkInterfaces := []computev1alpha1.NetworkInterface{
-			{
-				Name: "networkinterface1",
-				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
-					NetworkInterfaceRef: &corev1.LocalObjectReference{
-						Name: networkInterface2.Name,
-					},
-				},
-			},
-			{
-				Name: "networkinterface2",
-				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
-					NetworkInterfaceRef: &corev1.LocalObjectReference{
-						Name: networkInterfaceWithWrongNetwork.Name,
-					},
-				},
-			},
-		}
-		machine2 := newMachine(ns.Name, "machine-2", networkInterfaces)
-		Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
-
-		By("creating node2 object with a provider ID referencing the machine2")
-		node2 := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: machine2.Name,
-			},
-			Spec: corev1.NodeSpec{
-				ProviderID: getProviderID(machine2.Namespace, machine2.Name),
-			},
-		}
-		Expect(k8sClient.Create(ctx, node2)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, node2)
-
-		By("failing if no public IP is present for LoadBalancer")
-		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
-		defer cancel()
-		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
-
-		By("getting the LoadBalancer")
-		loadBalancer := &networkingv1alpha1.LoadBalancer{}
-		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, service)}
-		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
-
-		By("inspecting the LoadBalancer")
-		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
-
-		By("patching public IP into LoadBalancer status")
-		Eventually(UpdateStatus(loadBalancer, func() {
-			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")}
-		})).Should(Succeed())
-
-		By("creating LoadBalancer for service")
-		lbStatus, err := olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(lbStatus).To(Equal(&corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{{IP: "100.0.0.1"}},
+		By("ensuring load balancer for service")
+		Expect(lbProvider.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).To(Equal(&corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
 		}))
 
-		By("ensuring destinations of load balancer routing gets updated for node and node2")
-		err = olb.UpdateLoadBalancer(ctx, clusterName, service, []*corev1.Node{node, node2})
-		Expect(err).NotTo(HaveOccurred())
+		By("ensuring that the load balancer is of type public")
+		Eventually(Object(loadBalancer)).Should(SatisfyAll(
+			HaveField("Spec.Type", Equal(networkingv1alpha1.LoadBalancerTypePublic))))
+
+		By("ensuring destinations of load balancer routing")
 		lbRouting := &networkingv1alpha1.LoadBalancerRouting{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: service.Namespace,
@@ -279,79 +326,271 @@ var _ = Describe("LoadBalancer", func() {
 				Name:       loadBalancer.Name,
 				UID:        loadBalancer.UID,
 			})),
-			// netInterface2 will not be listed in Destinations, because network "foo" used by netInterface2 does not exist
 			HaveField("Destinations", ContainElements([]commonv1alpha1.LocalUIDReference{
 				{
-					Name: netInterface.Name,
-					UID:  netInterface.UID,
+					Name: networkInterface.Name,
+					UID:  networkInterface.UID,
+				},
+			})),
+		))
+
+		By("deleting the load balancer")
+		Expect(lbProvider.EnsureLoadBalancerDeleted(ctx, clusterName, service)).To(Succeed())
+	})
+
+	It("should update LoadBalancer", func(ctx SpecContext) {
+		By("creating a machine object")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
+				Image:           "my-image:latest",
+				Volumes:         []computev1alpha1.Volume{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
+
+		By("creating a network interface for machine")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface"),
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.1"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterface)
+
+		By("creating a network interface for machine with wrong network")
+		networkInterfaceFoo := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterfacefoo"),
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: "foo"},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.2"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterfaceFoo)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterfaceFoo)
+
+		By("creating node object with a provider ID referencing the machine")
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: machine.Name,
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(machine.Namespace, machine.Name),
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
+		By("patching the network interfaces of the machine")
+		Eventually(Update(machine, func() {
+			machine.Spec.NetworkInterfaces = []computev1alpha1.NetworkInterface{
+				{
+					Name: "primary",
+					NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+						NetworkInterfaceRef: &corev1.LocalObjectReference{
+							Name: networkInterface.Name,
+						},
+					},
+				},
+				{
+					Name: "secondary",
+					NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+						NetworkInterfaceRef: &corev1.LocalObjectReference{
+							Name: networkInterfaceFoo.Name,
+						},
+					},
+				},
+			}
+		})).Should(Succeed())
+
+		By("creating test service of type load balancer")
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "service-",
+				Namespace:    ns.Name,
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "https",
+						Protocol:   "TCP",
+						Port:       443,
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, service)
+
+		By("failing if no public IP is present for load balancer")
+		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+		Expect(lbProvider.EnsureLoadBalancer(ensureCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
+
+		By("ensuring the load balancer type is internal")
+		loadBalancer := &networkingv1alpha1.LoadBalancer{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      lbProvider.GetLoadBalancerName(ctx, clusterName, service),
+			},
+		}
+		Eventually(Object(loadBalancer)).Should(SatisfyAll(
+			HaveField("Spec.Type", Equal(networkingv1alpha1.LoadBalancerTypePublic))))
+
+		By("patching internal IP in load balancer status")
+		Eventually(UpdateStatus(loadBalancer, func() {
+			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.10")}
+		})).Should(Succeed())
+
+		By("ensuring load balancer for service")
+		Expect(lbProvider.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).
+			To(Equal(&corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "100.0.0.10"}},
+			}))
+
+		By("creating a second machine object")
+		machine2 := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
+				Image:           "my-image:latest",
+				Volumes:         []computev1alpha1.Volume{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine2)
+
+		By("creating a network interface for the second machine")
+		networkInterface2 := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface2"),
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.2"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine2.Name,
+					UID:  machine2.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface2)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterface2)
+
+		By("patching the network interfaces of the machine")
+		Eventually(Update(machine2, func() {
+			machine2.Spec.NetworkInterfaces = []computev1alpha1.NetworkInterface{
+				{
+					Name: "primary",
+					NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+						NetworkInterfaceRef: &corev1.LocalObjectReference{
+							Name: networkInterface2.Name,
+						},
+					},
+				},
+			}
+		})).Should(Succeed())
+
+		By("creating node object with a provider ID referencing the machine")
+		node2 := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: machine2.Name,
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(machine2.Namespace, machine2.Name),
+			},
+		}
+		Expect(k8sClient.Create(ctx, node2)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node2)
+
+		By("ensuring destinations of load balancer routing gets updated for node and node2")
+		Expect(lbProvider.UpdateLoadBalancer(ctx, clusterName, service, []*corev1.Node{node, node2})).NotTo(HaveOccurred())
+		lbRouting := &networkingv1alpha1.LoadBalancerRouting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: service.Namespace,
+				Name:      loadBalancer.Name,
+			},
+		}
+		Eventually(Object(lbRouting)).Should(SatisfyAll(
+			HaveField("ObjectMeta.OwnerReferences", ContainElement(metav1.OwnerReference{
+				APIVersion: "networking.api.onmetal.de/v1alpha1",
+				Kind:       "LoadBalancer",
+				Name:       loadBalancer.Name,
+				UID:        loadBalancer.UID,
+			})),
+			// networkInterfaceFoo will not be listed in destinations, because network "foo" used by
+			// networkInterfaceFoo does not exist
+			HaveField("Destinations", ContainElements([]commonv1alpha1.LocalUIDReference{
+				{
+					Name: networkInterface.Name,
+					UID:  networkInterface.UID,
 				},
 				{
 					Name: networkInterface2.Name,
 					UID:  networkInterface2.UID,
-				}}))))
+				},
+			})),
+		))
 	})
 
-	It("should get LoadBalancer info", func(ctx SpecContext) {
+	It("should fail to get load balancer info if no load balancer is present", func(ctx SpecContext) {
+		By("creating test service of type LoadBalancer")
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "service-",
+				Namespace:    ns.Name,
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "https",
+						Protocol:   "TCP",
+						Port:       443,
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, service)
+
 		By("ensuring that GetLoadBalancer returns instance not found for non existing object")
-		_, exist, err := olb.GetLoadBalancer(ctx, "foo", service)
+		_, exist, err := lbProvider.GetLoadBalancer(ctx, "foo", &corev1.Service{})
 		Expect(err).To(HaveOccurred())
 		Expect(exist).To(BeFalse())
 	})
-
-	It("should delete LoadBalancer", func(ctx SpecContext) {
-		By("failing if no public IP is present for LoadBalancer")
-		ensureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
-		defer cancel()
-		Expect(olb.EnsureLoadBalancer(ensureCtx, clusterName, service, []*corev1.Node{node})).Error().To(HaveOccurred())
-
-		By("getting the LoadBalancer")
-		loadBalancer := &networkingv1alpha1.LoadBalancer{}
-		loadBalancerKey := client.ObjectKey{Namespace: ns.Name, Name: olb.GetLoadBalancerName(ctx, clusterName, service)}
-		Expect(k8sClient.Get(ctx, loadBalancerKey, loadBalancer)).To(Succeed())
-
-		By("inspecting the LoadBalancer")
-		Expect(loadBalancer.Spec.Type).To(Equal(networkingv1alpha1.LoadBalancerTypePublic))
-
-		By("patching public IP into LoadBalancer status")
-		Eventually(UpdateStatus(loadBalancer, func() {
-			loadBalancer.Status.IPs = []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}
-		})).Should(Succeed())
-
-		By("ensuring LoadBalancer for service")
-		Expect(olb.EnsureLoadBalancer(ctx, clusterName, service, []*corev1.Node{node})).
-			To(Equal(&corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
-			}))
-
-		By("deleting the LoadBalancer")
-		Expect(olb.EnsureLoadBalancerDeleted(ctx, clusterName, service)).Error().To(Not(HaveOccurred()))
-	})
 })
-
-func newNetworkInterface(namespace string, name string, networkName string, ip string) *networkingv1alpha1.NetworkInterface {
-	return &networkingv1alpha1.NetworkInterface{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: networkingv1alpha1.NetworkInterfaceSpec{
-			NetworkRef: corev1.LocalObjectReference{Name: networkName},
-			IPs:        []networkingv1alpha1.IPSource{{Value: commonv1alpha1.MustParseNewIP(ip)}},
-		},
-	}
-}
-
-func newMachine(namespace, name string, networkInterfaces []computev1alpha1.NetworkInterface) *computev1alpha1.Machine {
-	return &computev1alpha1.Machine{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: computev1alpha1.MachineSpec{
-			MachineClassRef:   corev1.LocalObjectReference{Name: "machine-class"},
-			Image:             "my-image:latest",
-			NetworkInterfaces: networkInterfaces,
-			Volumes:           []computev1alpha1.Volume{},
-		},
-	}
-}

--- a/pkg/cloudprovider/onmetal/routes_test.go
+++ b/pkg/cloudprovider/onmetal/routes_test.go
@@ -15,6 +15,11 @@
 package onmetal
 
 import (
+	"fmt"
+
+	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
+	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
+	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -23,72 +28,65 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
-
-	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
-	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
-	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
 )
 
 var _ = Describe("Routes", func() {
+	ns, cp, network, clusterName := SetupTest()
 
 	var (
-		route           *cloudprovider.Route
-		node            *corev1.Node
-		netInterface    *networkingv1alpha1.NetworkInterface
-		oRoutes         cloudprovider.Routes
-		destinationCIDR string
+		routesProvider cloudprovider.Routes
 	)
 
-	ns, _, network, clusterName := SetupTest()
-
 	BeforeEach(func(ctx SpecContext) {
-		By("creating machine")
-		networkInterfaces := []computev1alpha1.NetworkInterface{
-			{
-				Name: "networkinterface",
-				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
-					NetworkInterfaceRef: &corev1.LocalObjectReference{
-						Name: "machine-networkinterface",
-					},
-				},
+		By("setting the routes provider")
+		var ok bool
+		routesProvider, ok = (*cp).Routes()
+		Expect(ok).To(BeTrue())
+	})
+
+	It("should list Routes for all network interfaces in current network", func(ctx SpecContext) {
+		By("creating a machine object")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+				Labels:       map[string]string{LabeKeylClusterName: clusterName},
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
+				Image:           "my-image:latest",
+				Volumes:         []computev1alpha1.Volume{},
 			},
 		}
-		machine := newMachine(ns.Name, "machine", networkInterfaces)
-		machine.Labels = map[string]string{LabeKeylClusterName: clusterName}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, machine)
 
 		By("creating a network interface for machine")
-		netInterface = newNetworkInterface(ns.Name, "machine-networkinterface", network.Name, "10.0.0.5")
-		netInterface.Labels = map[string]string{LabeKeylClusterName: clusterName}
-		netInterface.Spec.MachineRef = &commonv1alpha1.LocalUIDReference{
-			Name: machine.Name,
-			UID:  machine.UID,
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface"),
+				Labels:    map[string]string{LabeKeylClusterName: clusterName},
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.1"),
+				}},
+				Prefixes: []networkingv1alpha1.PrefixSource{{
+					Value: commonv1alpha1.MustParseNewIPPrefix("100.0.0.1/24"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
 		}
-		ipPrefix := commonv1alpha1.MustParseIPPrefix("10.0.0.5/32")
-		netInterface.Spec.Prefixes = []networkingv1alpha1.PrefixSource{{
-			Value: &ipPrefix,
-		},
-		}
-		Expect(k8sClient.Create(ctx, netInterface)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, netInterface)
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterface)
 
-		By("creating a network interface2 for machine without cluster name label")
-		netInterface2 := newNetworkInterface(ns.Name, "machine-networkinterface2", network.Name, "10.0.0.6")
-		netInterface2.Spec.MachineRef = &commonv1alpha1.LocalUIDReference{
-			Name: machine.Name,
-			UID:  machine.UID,
-		}
-		ipPrefix2 := commonv1alpha1.MustParseIPPrefix("10.0.0.6/32")
-		netInterface2.Spec.Prefixes = []networkingv1alpha1.PrefixSource{{
-			Value: &ipPrefix2,
-		},
-		}
-		Expect(k8sClient.Create(ctx, netInterface2)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, netInterface2)
-
-		By("creating node object with a provider ID referencing the machine1")
-		node = &corev1.Node{
+		By("creating node object with a provider ID referencing the machine")
+		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: machine.Name,
 			},
@@ -99,132 +97,273 @@ var _ = Describe("Routes", func() {
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, node)
 
-		By("patching the network interface status to have a valid internal IP address")
-		netInterfaceBase := netInterface.DeepCopy()
-		netInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
-		netInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
-		netInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("10.0.0.5/32")}
-		Expect(k8sClient.Status().Patch(ctx, netInterface, client.MergeFrom(netInterfaceBase))).To(Succeed())
+		By("patching the addresses node status")
+		nodeBase := node.DeepCopy()
+		node.Status.Addresses = []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "100.0.0.1",
+			},
+		}
+		Expect(k8sClient.Status().Patch(ctx, node, client.MergeFrom(nodeBase))).To(Succeed())
+
+		By("patching the network interface status to indicate availability and correct binding")
+		networkInterfaceBase := networkInterface.DeepCopy()
+		networkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
+		networkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
+		networkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("100.0.0.1/24")}
+		Expect(k8sClient.Status().Patch(ctx, networkInterface, client.MergeFrom(networkInterfaceBase))).To(Succeed())
 
 		By("patching the machine status to have a valid internal IP address")
 		machineBase := machine.DeepCopy()
-		machine.Status.State = computev1alpha1.MachineStateRunning
-		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{{
-			Name:  networkInterfaces[0].Name,
-			Phase: computev1alpha1.NetworkInterfacePhaseBound,
-			IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.5")},
-		}}
-		Expect(k8sClient.Status().Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed())
-
-		destinationCIDR = "10.0.0.5/32"
-		route = &cloudprovider.Route{
-			Name:            clusterName + "-" + destinationCIDR,
-			DestinationCIDR: destinationCIDR,
-			TargetNode:      types.NodeName(node.Name),
-			TargetNodeAddresses: []corev1.NodeAddress{{
-				Type:    corev1.NodeInternalIP,
-				Address: "10.0.0.5",
-			}},
-		}
-
-		By("getting the routes interface")
-		var ok bool
-		oRoutes, ok = cloudProvider.Routes()
-		Expect(ok).To(BeTrue())
-	})
-
-	It("should list Routes for all network interfaces in current network", func(ctx SpecContext) {
-		By("getting list of routes")
-		routes := []*cloudprovider.Route{{
-			Name:            clusterName + "-" + destinationCIDR,
-			DestinationCIDR: destinationCIDR,
-			TargetNode:      types.NodeName(node.Name),
-		}}
-		Expect(oRoutes.ListRoutes(ctx, clusterName)).Should(Equal(routes))
-	})
-
-	It("should not list Routes for Network Interface not having cluster name label", func(ctx SpecContext) {
-		By("creating machine2")
-		networkInterfaces := []computev1alpha1.NetworkInterface{
+		machine.Spec.NetworkInterfaces = []computev1alpha1.NetworkInterface{
 			{
-				Name: "networkinterface2",
+				Name: "primary",
 				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
 					NetworkInterfaceRef: &corev1.LocalObjectReference{
-						Name: "machine2-networkinterface2",
+						Name: fmt.Sprintf("%s-%s", machine.Name, "primary"),
 					},
 				},
 			},
 		}
-		machine2 := newMachine(ns.Name, "machine2", networkInterfaces)
-		Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, machine2)
-
-		By("creating a network interface2 for machine2")
-		netInterface2 := newNetworkInterface(ns.Name, "machine2-networkinterface2", network.Name, "10.0.0.7")
-		netInterface2.Spec.MachineRef = &commonv1alpha1.LocalUIDReference{
-			Name: machine2.Name,
-			UID:  machine2.UID,
-		}
-		ipPrefix := commonv1alpha1.MustParseIPPrefix("10.0.0.7/32")
-		netInterface2.Spec.Prefixes = []networkingv1alpha1.PrefixSource{{
-			Value: &ipPrefix,
-		},
-		}
-		Expect(k8sClient.Create(ctx, netInterface2)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, netInterface2)
-
-		By("patching the network interface2 status to have a valid internal IP address")
-		netInterface2Base := netInterface2.DeepCopy()
-		netInterface2.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
-		netInterface2.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
-		netInterface2.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("10.0.0.7/32")}
-		Expect(k8sClient.Status().Patch(ctx, netInterface2, client.MergeFrom(netInterface2Base))).To(Succeed())
-
-		By("patching the machine status to have a valid internal IP address")
-		machine2Base := machine2.DeepCopy()
-		machine2.Status.State = computev1alpha1.MachineStateRunning
-		machine2.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{{
-			Name:  networkInterfaces[0].Name,
+		machine.Status.State = computev1alpha1.MachineStateRunning
+		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{{
+			Name:  "primary",
 			Phase: computev1alpha1.NetworkInterfacePhaseBound,
-			IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.7")},
+			IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
 		}}
-		Expect(k8sClient.Status().Patch(ctx, machine2, client.MergeFrom(machine2Base))).To(Succeed())
+		Expect(k8sClient.Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed())
 
 		By("getting list of routes")
-		routes := []*cloudprovider.Route{{
-			Name:            clusterName + "-" + destinationCIDR,
-			DestinationCIDR: destinationCIDR,
+		Expect(routesProvider.ListRoutes(ctx, clusterName)).Should(Equal([]*cloudprovider.Route{{
+			Name:            clusterName + "-" + "100.0.0.1/24",
+			DestinationCIDR: "100.0.0.1/24",
 			TargetNode:      types.NodeName(node.Name),
+			TargetNodeAddresses: []corev1.NodeAddress{{
+				Type:    corev1.NodeInternalIP,
+				Address: "100.0.0.1",
+			}},
+		}}))
+	})
+
+	It("should not list routes for network interface not having cluster name label", func(ctx SpecContext) {
+		By("creating a machine object without cluster label")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
+				Image:           "my-image:latest",
+				Volumes:         []computev1alpha1.Volume{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
+
+		By("creating a network interface for machine without cluster label")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface"),
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.1"),
+				}},
+				Prefixes: []networkingv1alpha1.PrefixSource{{
+					Value: commonv1alpha1.MustParseNewIPPrefix("100.0.0.1/24"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterface)
+
+		By("creating node object with a provider ID referencing the machine")
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: machine.Name,
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(machine.Namespace, machine.Name),
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
+		By("patching the addresses node status")
+		nodeBase := node.DeepCopy()
+		node.Status.Addresses = []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "100.0.0.1",
+			},
+		}
+		Expect(k8sClient.Status().Patch(ctx, node, client.MergeFrom(nodeBase))).To(Succeed())
+
+		By("patching the network interface status to indicate availability and correct binding")
+		networkInterfaceBase := networkInterface.DeepCopy()
+		networkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
+		networkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
+		networkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("100.0.0.1/24")}
+		Expect(k8sClient.Status().Patch(ctx, networkInterface, client.MergeFrom(networkInterfaceBase))).To(Succeed())
+
+		By("patching the machine status to have a valid internal IP address")
+		machineBase := machine.DeepCopy()
+		machine.Spec.NetworkInterfaces = []computev1alpha1.NetworkInterface{
+			{
+				Name: "primary",
+				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+					NetworkInterfaceRef: &corev1.LocalObjectReference{
+						Name: fmt.Sprintf("%s-%s", machine.Name, "primary"),
+					},
+				},
+			},
+		}
+		machine.Status.State = computev1alpha1.MachineStateRunning
+		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{{
+			Name:  "primary",
+			Phase: computev1alpha1.NetworkInterfacePhaseBound,
+			IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
 		}}
-		Expect(oRoutes.ListRoutes(ctx, clusterName)).Should(Equal(routes))
+		Expect(k8sClient.Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed())
+
+		By("getting list of routes")
+		var routes []*cloudprovider.Route
+		Expect(routesProvider.ListRoutes(ctx, clusterName)).Should(Equal(routes))
 	})
 
-	It("should add/check prefix for Route", func(ctx SpecContext) {
-		By("ensuring network interface prefix already exists")
-		Expect(oRoutes.CreateRoute(ctx, clusterName, "my-route", route)).To(Succeed())
-		Eventually(Object(netInterface)).Should(SatisfyAll(
-			HaveField("Name", "machine-networkinterface"),
-			HaveField("Status.Prefixes", []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix(destinationCIDR)}),
+	It("should ensure that a prefix has been created for a route", func(ctx SpecContext) {
+		By("creating a machine object")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+				Labels:       map[string]string{LabeKeylClusterName: clusterName},
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
+				Image:           "my-image:latest",
+				Volumes:         []computev1alpha1.Volume{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
+
+		By("creating a network interface for machine")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "primary"),
+				Labels:    map[string]string{LabeKeylClusterName: clusterName},
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: commonv1alpha1.MustParseNewIP("100.0.0.1"),
+				}},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, networkInterface)
+
+		By("creating node object with a provider ID referencing the machine")
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: machine.Name,
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(machine.Namespace, machine.Name),
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
+		By("patching the addresses node status")
+		nodeBase := node.DeepCopy()
+		node.Status.Addresses = []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "100.0.0.1",
+			},
+		}
+		Expect(k8sClient.Status().Patch(ctx, node, client.MergeFrom(nodeBase))).To(Succeed())
+
+		By("patching the network interface status to indicate availability and correct binding")
+		networkInterfaceBase := networkInterface.DeepCopy()
+		networkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
+		networkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
+		Expect(k8sClient.Status().Patch(ctx, networkInterface, client.MergeFrom(networkInterfaceBase))).To(Succeed())
+
+		By("patching the machine status to have a valid internal IP address")
+		machineBase := machine.DeepCopy()
+		machine.Spec.NetworkInterfaces = []computev1alpha1.NetworkInterface{
+			{
+				Name: "primary",
+				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+					NetworkInterfaceRef: &corev1.LocalObjectReference{
+						Name: fmt.Sprintf("%s-%s", machine.Name, "primary"),
+					},
+				},
+			},
+		}
+		machine.Status.State = computev1alpha1.MachineStateRunning
+		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{{
+			Name:  "primary",
+			Phase: computev1alpha1.NetworkInterfacePhaseBound,
+			IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
+		}}
+		Expect(k8sClient.Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed())
+
+		By("ensuring that the route is represented by a prefix in the network interface spec")
+		Expect(routesProvider.CreateRoute(ctx, clusterName, "my-route", &cloudprovider.Route{
+			Name:            "foo",
+			TargetNode:      types.NodeName(node.Name),
+			DestinationCIDR: "100.0.0.1/24",
+			TargetNodeAddresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: "100.0.0.1",
+				},
+			},
+		})).To(Succeed())
+		Eventually(Object(networkInterface)).Should(SatisfyAll(
+			HaveField("Spec.Prefixes", ContainElement(networkingv1alpha1.PrefixSource{
+				Value: commonv1alpha1.MustParseNewIPPrefix("100.0.0.1/24"),
+			})),
 		))
 
-		By("creating new prefix for Route")
-		route.DestinationCIDR = "10.0.0.3/32" //assign new CIDR to create new prefix
-		Expect(oRoutes.CreateRoute(ctx, clusterName, "my-route", route)).To(Succeed())
-		ipPrefix := commonv1alpha1.MustParseIPPrefix(route.DestinationCIDR)
-		Eventually(Object(netInterface)).Should(SatisfyAll(
-			HaveField("Name", "machine-networkinterface"),
-			HaveField("Spec.Prefixes", ContainElement(SatisfyAll(
-				HaveField("Value", &ipPrefix),
-			))),
-		))
-	})
+		By("patching the network interface status to have the correct prefix in status")
+		networkInterfaceBase = networkInterface.DeepCopy()
+		networkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("100.0.0.1/24")}
+		Expect(k8sClient.Status().Patch(ctx, networkInterface, client.MergeFrom(networkInterfaceBase))).To(Succeed())
 
-	It("should delete prefix for Route", func(ctx SpecContext) {
-		By("deleting prefix for Route")
-		Expect(oRoutes.DeleteRoute(ctx, clusterName, route)).To(Succeed())
-		var ipPrefix []networkingv1alpha1.PrefixSource
-		Eventually(Object(netInterface)).Should(SatisfyAll(
-			HaveField("Spec.Prefixes", ipPrefix),
+		By("deleting prefix for route")
+		Expect(routesProvider.DeleteRoute(ctx, clusterName, &cloudprovider.Route{
+			Name:            "foo",
+			TargetNode:      types.NodeName(node.Name),
+			DestinationCIDR: "100.0.0.1/24",
+			TargetNodeAddresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: "100.0.0.1",
+				},
+			},
+		})).To(Succeed())
+
+		var prefixSources []networkingv1alpha1.PrefixSource
+		Eventually(Object(networkInterface)).Should(SatisfyAll(
+			HaveField("Spec.Prefixes", Equal(prefixSources)),
 		))
 	})
 })


### PR DESCRIPTION
# Proposed Changes

- Refactor suite tests for `Routes` and `LoadBalancer`
- Fix the way a `NetworkInterface` is being looked up. Honour both `Ephemeral` and `NetworkInterfaceRef` in `Machine` spec.
- Fix context handling when polling the `LoadBalancer` readiness