### PR TITLE
Extend Testing of Routes Controller Methods for Machine Network Interfaces

### DIFF
--- a/pkg/cloudprovider/onmetal/constants.go
+++ b/pkg/cloudprovider/onmetal/constants.go
@@ -25,6 +25,6 @@ const (
 	AnnotationKeyServiceNamespace = "service-namespace"
 	// AnnotationKeyServiceUID is the service UID annotation key name
 	AnnotationKeyServiceUID = "service-uid"
-	// LabeKeylClusterName is the cluster name label key name
-	LabeKeylClusterName = "kubernetes.io/cluster"
+	// LabelKeyClusterName is the label key name used to identify the cluster name in Kubernetes labels
+	LabelKeyClusterName = "kubernetes.io/cluster"
 )

--- a/pkg/cloudprovider/onmetal/instances_v2.go
+++ b/pkg/cloudprovider/onmetal/instances_v2.go
@@ -98,7 +98,7 @@ func (o *onmetalInstancesV2) InstanceMetadata(ctx context.Context, node *corev1.
 	if machine.Labels == nil {
 		machine.Labels = make(map[string]string)
 	}
-	machine.Labels[LabeKeylClusterName] = o.clusterName
+	machine.Labels[LabelKeyClusterName] = o.clusterName
 	klog.V(2).InfoS("Adding cluster name label to Machine object", "Machine", client.ObjectKeyFromObject(machine), "Node", node.Name)
 	if err := o.onmetalClient.Patch(ctx, machine, client.MergeFrom(machineBase)); err != nil {
 		return nil, fmt.Errorf("failed to patch Machine %s for Node %s: %w", client.ObjectKeyFromObject(machine), node.Name, err)
@@ -116,8 +116,8 @@ func (o *onmetalInstancesV2) InstanceMetadata(ctx context.Context, node *corev1.
 		if nic.Labels == nil {
 			nic.Labels = make(map[string]string)
 		}
-		nic.Labels[LabeKeylClusterName] = o.clusterName
-		klog.V(2).InfoS("Adding cluster name label to NetworkInterface", "NetworkInterface", client.ObjectKeyFromObject(nic), "Node", node.Name, "Label", nic.Labels[LabeKeylClusterName])
+		nic.Labels[LabelKeyClusterName] = o.clusterName
+		klog.V(2).InfoS("Adding cluster name label to NetworkInterface", "NetworkInterface", client.ObjectKeyFromObject(nic), "Node", node.Name, "Label", nic.Labels[LabelKeyClusterName])
 		if err := o.onmetalClient.Patch(ctx, nic, client.MergeFrom(nicBase)); err != nil {
 			return nil, fmt.Errorf("failed to patch NetworkInterface %s for Node %s: %w", client.ObjectKeyFromObject(nic), node.Name, err)
 		}

--- a/pkg/cloudprovider/onmetal/instances_v2_test.go
+++ b/pkg/cloudprovider/onmetal/instances_v2_test.go
@@ -144,12 +144,12 @@ var _ = Describe("InstancesV2", func() {
 
 		By("ensuring cluster name label is added to Machine object")
 		Eventually(Object(machine)).Should(SatisfyAll(
-			HaveField("Labels", map[string]string{LabeKeylClusterName: clusterName}),
+			HaveField("Labels", map[string]string{LabelKeyClusterName: clusterName}),
 		))
 
 		By("ensuring cluster name label is added to network interface of Machine object")
 		Eventually(Object(netInterface)).Should(SatisfyAll(
-			HaveField("Labels", map[string]string{LabeKeylClusterName: clusterName}),
+			HaveField("Labels", map[string]string{LabelKeyClusterName: clusterName}),
 		))
 
 	})

--- a/pkg/cloudprovider/onmetal/routes.go
+++ b/pkg/cloudprovider/onmetal/routes.go
@@ -53,7 +53,7 @@ func (o onmetalRoutes) ListRoutes(ctx context.Context, clusterName string) ([]*c
 	if err := o.onmetalClient.List(ctx, networkInterfaces, client.InNamespace(o.onmetalNamespace), client.MatchingFields{
 		networkInterfaceSpecNetworkRefNameField: o.cloudConfig.NetworkName,
 	}, client.MatchingLabels{
-		LabeKeylClusterName: clusterName,
+		LabelKeyClusterName: clusterName,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/onmetal/routes_test.go
+++ b/pkg/cloudprovider/onmetal/routes_test.go
@@ -19,6 +19,7 @@ import (
 
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
+	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,11 +62,11 @@ var _ = Describe("Routes", func() {
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, machine)
 
-		By("creating a network interface for machine")
-		networkInterface := &networkingv1alpha1.NetworkInterface{
+		By("creating a static network interface for machine")
+		staticNetworkInterface := &networkingv1alpha1.NetworkInterface{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface"),
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "primary"),
 				Labels:    map[string]string{LabelKeyClusterName: clusterName},
 			},
 			Spec: networkingv1alpha1.NetworkInterfaceSpec{
@@ -82,8 +83,38 @@ var _ = Describe("Routes", func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, networkInterface)
+		Expect(k8sClient.Create(ctx, staticNetworkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, staticNetworkInterface)
+
+		By("creating an ephemeral network interface for machine")
+		ephemeralNetworkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "ephemeral"),
+				Labels:    map[string]string{LabelKeyClusterName: clusterName},
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{
+					{
+						Ephemeral: &networkingv1alpha1.EphemeralPrefixSource{
+							PrefixTemplate: &ipamv1alpha1.PrefixTemplateSpec{
+								Spec: ipamv1alpha1.PrefixSpec{
+									Prefix: commonv1alpha1.MustParseNewIPPrefix("192.168.0.1/32"),
+								},
+							},
+						},
+					},
+				},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ephemeralNetworkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, ephemeralNetworkInterface)
 
 		By("creating node object with a provider ID referencing the machine")
 		node := &corev1.Node{
@@ -104,15 +135,26 @@ var _ = Describe("Routes", func() {
 				Type:    corev1.NodeInternalIP,
 				Address: "100.0.0.1",
 			},
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "192.168.0.1",
+			},
 		}
 		Expect(k8sClient.Status().Patch(ctx, node, client.MergeFrom(nodeBase))).To(Succeed())
 
-		By("patching the network interface status to indicate availability and correct binding")
-		networkInterfaceBase := networkInterface.DeepCopy()
-		networkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
-		networkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
-		networkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("100.0.0.1/24")}
-		Expect(k8sClient.Status().Patch(ctx, networkInterface, client.MergeFrom(networkInterfaceBase))).To(Succeed())
+		By("patching the static network interface status to indicate availability and correct binding")
+		staticNetworkInterfaceBase := staticNetworkInterface.DeepCopy()
+		staticNetworkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
+		staticNetworkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
+		staticNetworkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("100.0.0.1/24")}
+		Expect(k8sClient.Status().Patch(ctx, staticNetworkInterface, client.MergeFrom(staticNetworkInterfaceBase))).To(Succeed())
+
+		By("patching the ephemeral network interface status to indicate availability and correct binding")
+		ephemeralNetworkInterfaceBase := ephemeralNetworkInterface.DeepCopy()
+		ephemeralNetworkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
+		ephemeralNetworkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
+		ephemeralNetworkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("192.168.0.1/32")}
+		Expect(k8sClient.Status().Patch(ctx, ephemeralNetworkInterface, client.MergeFrom(ephemeralNetworkInterfaceBase))).To(Succeed())
 
 		By("patching the machine status to have a valid internal IP address")
 		machineBase := machine.DeepCopy()
@@ -125,25 +167,63 @@ var _ = Describe("Routes", func() {
 					},
 				},
 			},
+			{
+				Name: "ephemeral",
+				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+					NetworkInterfaceRef: &corev1.LocalObjectReference{
+						Name: fmt.Sprintf("%s-%s", machine.Name, "ephemeral"),
+					},
+				},
+			},
 		}
 		machine.Status.State = computev1alpha1.MachineStateRunning
-		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{{
-			Name:  "primary",
-			Phase: computev1alpha1.NetworkInterfacePhaseBound,
-			IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
-		}}
+		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{
+			{
+				Name:  "primary",
+				Phase: computev1alpha1.NetworkInterfacePhaseBound,
+				IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
+			},
+			{
+				Name:  "ephemeral",
+				Phase: computev1alpha1.NetworkInterfacePhaseBound,
+				IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("192.168.0.1")},
+			},
+		}
 		Expect(k8sClient.Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed())
 
 		By("getting list of routes")
-		Expect(routesProvider.ListRoutes(ctx, clusterName)).Should(Equal([]*cloudprovider.Route{{
-			Name:            clusterName + "-" + "100.0.0.1/24",
-			DestinationCIDR: "100.0.0.1/24",
-			TargetNode:      types.NodeName(node.Name),
-			TargetNodeAddresses: []corev1.NodeAddress{{
-				Type:    corev1.NodeInternalIP,
-				Address: "100.0.0.1",
-			}},
-		}}))
+		Expect(routesProvider.ListRoutes(ctx, clusterName)).Should(ConsistOf([]*cloudprovider.Route{
+			{
+				Name:            clusterName + "-" + "100.0.0.1/24",
+				DestinationCIDR: "100.0.0.1/24",
+				TargetNode:      types.NodeName(node.Name),
+				TargetNodeAddresses: []corev1.NodeAddress{
+					{
+						Type:    corev1.NodeInternalIP,
+						Address: "100.0.0.1",
+					},
+					{
+						Type:    corev1.NodeInternalIP,
+						Address: "192.168.0.1",
+					},
+				},
+			},
+			{
+				Name:            clusterName + "-" + "192.168.0.1/32",
+				DestinationCIDR: "192.168.0.1/32",
+				TargetNode:      types.NodeName(node.Name),
+				TargetNodeAddresses: []corev1.NodeAddress{
+					{
+						Type:    corev1.NodeInternalIP,
+						Address: "100.0.0.1",
+					},
+					{
+						Type:    corev1.NodeInternalIP,
+						Address: "192.168.0.1",
+					},
+				},
+			},
+		}))
 	})
 
 	It("should not list routes for network interface not having cluster name label", func(ctx SpecContext) {
@@ -256,8 +336,8 @@ var _ = Describe("Routes", func() {
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, machine)
 
-		By("creating a network interface for machine")
-		networkInterface := &networkingv1alpha1.NetworkInterface{
+		By("creating a static network interface for machine")
+		staticNetworkInterface := &networkingv1alpha1.NetworkInterface{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
 				Name:      fmt.Sprintf("%s-%s", machine.Name, "primary"),
@@ -274,8 +354,38 @@ var _ = Describe("Routes", func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, networkInterface)
+		Expect(k8sClient.Create(ctx, staticNetworkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, staticNetworkInterface)
+
+		By("creating an ephemeral network interface for machine")
+		ephemeralNetworkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      fmt.Sprintf("%s-%s", machine.Name, "ephemeral"),
+				Labels:    map[string]string{LabelKeyClusterName: clusterName},
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
+				IPs: []networkingv1alpha1.IPSource{
+					{
+						Ephemeral: &networkingv1alpha1.EphemeralPrefixSource{
+							PrefixTemplate: &ipamv1alpha1.PrefixTemplateSpec{
+								Spec: ipamv1alpha1.PrefixSpec{
+									Prefix: commonv1alpha1.MustParseNewIPPrefix("192.168.0.1/32"),
+								},
+							},
+						},
+					},
+				},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				MachineRef: &commonv1alpha1.LocalUIDReference{
+					Name: machine.Name,
+					UID:  machine.UID,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ephemeralNetworkInterface)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, ephemeralNetworkInterface)
 
 		By("creating node object with a provider ID referencing the machine")
 		node := &corev1.Node{
@@ -296,14 +406,24 @@ var _ = Describe("Routes", func() {
 				Type:    corev1.NodeInternalIP,
 				Address: "100.0.0.1",
 			},
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "192.168.0.1",
+			},
 		}
 		Expect(k8sClient.Status().Patch(ctx, node, client.MergeFrom(nodeBase))).To(Succeed())
 
-		By("patching the network interface status to indicate availability and correct binding")
-		networkInterfaceBase := networkInterface.DeepCopy()
-		networkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
-		networkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
-		Expect(k8sClient.Status().Patch(ctx, networkInterface, client.MergeFrom(networkInterfaceBase))).To(Succeed())
+		By("patching the static network interface status to indicate availability and correct binding")
+		staticNetworkInterfaceBase := staticNetworkInterface.DeepCopy()
+		staticNetworkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
+		staticNetworkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
+		Expect(k8sClient.Status().Patch(ctx, staticNetworkInterface, client.MergeFrom(staticNetworkInterfaceBase))).To(Succeed())
+
+		By("patching the ephemeral network interface status to indicate availability and correct binding")
+		ephemeralNetworkInterfaceBase := ephemeralNetworkInterface.DeepCopy()
+		ephemeralNetworkInterface.Status.State = networkingv1alpha1.NetworkInterfaceStateAvailable
+		ephemeralNetworkInterface.Status.Phase = networkingv1alpha1.NetworkInterfacePhaseBound
+		Expect(k8sClient.Status().Patch(ctx, ephemeralNetworkInterface, client.MergeFrom(ephemeralNetworkInterfaceBase))).To(Succeed())
 
 		By("patching the machine status to have a valid internal IP address")
 		machineBase := machine.DeepCopy()
@@ -316,17 +436,32 @@ var _ = Describe("Routes", func() {
 					},
 				},
 			},
+			{
+				Name: "ephemeral",
+				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
+					NetworkInterfaceRef: &corev1.LocalObjectReference{
+						Name: fmt.Sprintf("%s-%s", machine.Name, "ephemeral"),
+					},
+				},
+			},
 		}
 		machine.Status.State = computev1alpha1.MachineStateRunning
-		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{{
-			Name:  "primary",
-			Phase: computev1alpha1.NetworkInterfacePhaseBound,
-			IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
-		}}
+		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{
+			{
+				Name:  "primary",
+				Phase: computev1alpha1.NetworkInterfacePhaseBound,
+				IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
+			},
+			{
+				Name:  "ephemeral",
+				Phase: computev1alpha1.NetworkInterfacePhaseBound,
+				IPs:   []commonv1alpha1.IP{commonv1alpha1.MustParseIP("192.168.0.1")},
+			},
+		}
 		Expect(k8sClient.Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed())
 
-		By("ensuring that the route is represented by a prefix in the network interface spec")
-		Expect(routesProvider.CreateRoute(ctx, clusterName, "my-route", &cloudprovider.Route{
+		By("ensuring that the route is represented by a prefix in the static network interface spec")
+		Expect(routesProvider.CreateRoute(ctx, clusterName, "my-route1", &cloudprovider.Route{
 			Name:            "foo",
 			TargetNode:      types.NodeName(node.Name),
 			DestinationCIDR: "100.0.0.1/24",
@@ -337,18 +472,41 @@ var _ = Describe("Routes", func() {
 				},
 			},
 		})).To(Succeed())
-		Eventually(Object(networkInterface)).Should(SatisfyAll(
+		Eventually(Object(staticNetworkInterface)).Should(SatisfyAll(
 			HaveField("Spec.Prefixes", ContainElement(networkingv1alpha1.PrefixSource{
 				Value: commonv1alpha1.MustParseNewIPPrefix("100.0.0.1/24"),
 			})),
 		))
 
-		By("patching the network interface status to have the correct prefix in status")
-		networkInterfaceBase = networkInterface.DeepCopy()
-		networkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("100.0.0.1/24")}
-		Expect(k8sClient.Status().Patch(ctx, networkInterface, client.MergeFrom(networkInterfaceBase))).To(Succeed())
+		By("ensuring that the route is represented by a prefix in the ephemeral network interface spec")
+		Expect(routesProvider.CreateRoute(ctx, clusterName, "my-route2", &cloudprovider.Route{
+			Name:            "bar",
+			TargetNode:      types.NodeName(node.Name),
+			DestinationCIDR: "192.168.0.1/32",
+			TargetNodeAddresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: "192.168.0.1",
+				},
+			},
+		})).To(Succeed())
+		Eventually(Object(ephemeralNetworkInterface)).Should(SatisfyAll(
+			HaveField("Spec.Prefixes", ContainElement(networkingv1alpha1.PrefixSource{
+				Value: commonv1alpha1.MustParseNewIPPrefix("192.168.0.1/32"),
+			})),
+		))
 
-		By("deleting prefix for route")
+		By("patching the static network interface status to have the correct prefix in status")
+		staticNetworkInterfaceBase = staticNetworkInterface.DeepCopy()
+		staticNetworkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("100.0.0.1/24")}
+		Expect(k8sClient.Status().Patch(ctx, staticNetworkInterface, client.MergeFrom(staticNetworkInterfaceBase))).To(Succeed())
+
+		By("patching the ephemeral network interface status to have the correct prefix in status")
+		ephemeralNetworkInterfaceBase = staticNetworkInterface.DeepCopy()
+		ephemeralNetworkInterface.Status.Prefixes = []commonv1alpha1.IPPrefix{commonv1alpha1.MustParseIPPrefix("192.168.0.1/32")}
+		Expect(k8sClient.Status().Patch(ctx, ephemeralNetworkInterface, client.MergeFrom(ephemeralNetworkInterfaceBase))).To(Succeed())
+
+		By("deleting prefix for static route")
 		Expect(routesProvider.DeleteRoute(ctx, clusterName, &cloudprovider.Route{
 			Name:            "foo",
 			TargetNode:      types.NodeName(node.Name),
@@ -362,7 +520,23 @@ var _ = Describe("Routes", func() {
 		})).To(Succeed())
 
 		var prefixSources []networkingv1alpha1.PrefixSource
-		Eventually(Object(networkInterface)).Should(SatisfyAll(
+		Eventually(Object(staticNetworkInterface)).Should(SatisfyAll(
+			HaveField("Spec.Prefixes", Equal(prefixSources)),
+		))
+
+		By("deleting prefix for ephemeral route")
+		Expect(routesProvider.DeleteRoute(ctx, clusterName, &cloudprovider.Route{
+			Name:            "bar",
+			TargetNode:      types.NodeName(node.Name),
+			DestinationCIDR: "192.168.0.1/32",
+			TargetNodeAddresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: "192.168.0.1",
+				},
+			},
+		})).To(Succeed())
+		Eventually(Object(ephemeralNetworkInterface)).Should(SatisfyAll(
 			HaveField("Spec.Prefixes", Equal(prefixSources)),
 		))
 	})

--- a/pkg/cloudprovider/onmetal/routes_test.go
+++ b/pkg/cloudprovider/onmetal/routes_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Routes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
 				GenerateName: "machine-",
-				Labels:       map[string]string{LabeKeylClusterName: clusterName},
+				Labels:       map[string]string{LabelKeyClusterName: clusterName},
 			},
 			Spec: computev1alpha1.MachineSpec{
 				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
@@ -66,7 +66,7 @@ var _ = Describe("Routes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
 				Name:      fmt.Sprintf("%s-%s", machine.Name, "networkinterface"),
-				Labels:    map[string]string{LabeKeylClusterName: clusterName},
+				Labels:    map[string]string{LabelKeyClusterName: clusterName},
 			},
 			Spec: networkingv1alpha1.NetworkInterfaceSpec{
 				NetworkRef: corev1.LocalObjectReference{Name: network.Name},
@@ -245,7 +245,7 @@ var _ = Describe("Routes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
 				GenerateName: "machine-",
-				Labels:       map[string]string{LabeKeylClusterName: clusterName},
+				Labels:       map[string]string{LabelKeyClusterName: clusterName},
 			},
 			Spec: computev1alpha1.MachineSpec{
 				MachineClassRef: corev1.LocalObjectReference{Name: "machine-class"},
@@ -261,7 +261,7 @@ var _ = Describe("Routes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
 				Name:      fmt.Sprintf("%s-%s", machine.Name, "primary"),
-				Labels:    map[string]string{LabeKeylClusterName: clusterName},
+				Labels:    map[string]string{LabelKeyClusterName: clusterName},
 			},
 			Spec: networkingv1alpha1.NetworkInterfaceSpec{
 				NetworkRef: corev1.LocalObjectReference{Name: network.Name},


### PR DESCRIPTION
- Extend routes tests to handle `Machine` instances that reference both ephemeral and static `NetworkInterface` instances Fixes #252
- Fix typos

 