### PR TITLE
Refactor `networkInterfaceName` generation and clean up test cases

### DIFF
--- a/pkg/cloudprovider/onmetal/routes.go
+++ b/pkg/cloudprovider/onmetal/routes.go
@@ -114,7 +114,7 @@ func (o onmetalRoutes) CreateRoute(ctx context.Context, clusterName string, name
 				// if the interface is found, add the prefix to the network interface
 				if interfaceFound {
 					// get the network interface object
-					networkInterfaceName := fmt.Sprintf("%s-%s", machine.Name, networkInterface.Name)
+					networkInterfaceName := getNetworkInterfaceName(machine, networkInterface)
 					nic := &networkingv1alpha1.NetworkInterface{}
 					if err := o.onmetalClient.Get(ctx, client.ObjectKey{Namespace: o.onmetalNamespace, Name: networkInterfaceName}, nic); err != nil {
 						return err

--- a/pkg/cloudprovider/onmetal/routes_test.go
+++ b/pkg/cloudprovider/onmetal/routes_test.go
@@ -75,7 +75,6 @@ var _ = Describe("Routes", func() {
 	})
 
 	It("should list Routes for all network interfaces in current network", func(ctx SpecContext) {
-
 		By("patching the machine with cluster name label")
 		baseMachine := machine.DeepCopy()
 		machine.ObjectMeta.Labels = map[string]string{LabelKeyClusterName: clusterName}
@@ -234,7 +233,6 @@ var _ = Describe("Routes", func() {
 	})
 
 	It("should not list routes for network interface not having cluster name label", func(ctx SpecContext) {
-
 		By("creating a network interface for machine without cluster label")
 		networkInterface := &networkingv1alpha1.NetworkInterface{
 			ObjectMeta: metav1.ObjectMeta{
@@ -301,7 +299,6 @@ var _ = Describe("Routes", func() {
 	})
 
 	It("should ensure that a prefix has been created for a route", func(ctx SpecContext) {
-
 		By("patching the machine with cluster name label")
 		baseMachine := machine.DeepCopy()
 		machine.ObjectMeta.Labels = map[string]string{LabelKeyClusterName: clusterName}


### PR DESCRIPTION
# Proposed Changes

- Change the `networkInterfaceName` generation to use the `getNetworkInterfaceName` function
- Remove unnecessary empty lines in the test cases

Fixes #281 