### PR TITLE
Update `golangci-lint` to in GH workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53.3
+          version: v1.55.2

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,11 +1,14 @@
 name: Size Label
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:
   size-label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: size-label


### PR DESCRIPTION
# Proposed Changes

- Update golangci-lint in GH workflow to v1.55.2
- Use pull_request in size workflow and set correct workflow permissions
